### PR TITLE
⚡️ [성능 향상] : DockerFile에 Gradle 영역에 Cache를 적용하여 빌드 과정&시간 단축

### DIFF
--- a/SpringBoot/Dockerfile
+++ b/SpringBoot/Dockerfile
@@ -1,6 +1,19 @@
-# --- 1단계: 빌드 ---
+# --- 1단계: 빌드 ver 1.0 ---
+#FROM gradle:8.4.0-jdk17 AS build
+#WORKDIR /app
+#COPY . .
+#RUN gradle clean build -x test
+
+# --- 1단계: 빌드 ver 1.1 ---
 FROM gradle:8.4.0-jdk17 AS build
 WORKDIR /app
+
+# 의존성 캐시를 위해 먼저 build.gradle만 복사
+# 소스 변경이 없으면 이 단계가 캐시
+COPY build.gradle settings.gradle ./
+RUN gradle dependencies || true
+
+# 이후 전체 소스를 복사
 COPY . .
 RUN gradle clean build -x test
 


### PR DESCRIPTION
SpringBoot 컨테이너 실행 시, 계속하여 gradle의 의존성을 재빌드하여 과정&시간적 비효율  발생   
Gradle 빌드 시,  캐싱을 적용하여 gradle 파일 내부에 변동이 없을 시 의존성 재빌드 과정  생략하는 로직 추가

기존 빌드 
```
# --- 1단계: 빌드 ver 1.0 ---
#FROM gradle:8.4.0-jdk17 AS build
#WORKDIR /app
#COPY . .
#RUN gradle clean build -x test
```

수정 후 빌드 : Gradle에 캐싱 적용 > 빌드 시간 단축 
```
# --- 1단계: 빌드 ver 1.1 ---
FROM gradle:8.4.0-jdk17 AS build
WORKDIR /app

# 의존성 캐시를 위해 먼저 build.gradle만 복사
# 소스 변경이 없으면 이 단계가 캐시
COPY build.gradle settings.gradle ./
RUN gradle dependencies || true

# 이후 전체 소스를 복사
COPY . .
RUN gradle clean build -x test
```