### PR TITLE
Feat/redis config

### DIFF
--- a/SpringBoot/src/main/resources/application.properties
+++ b/SpringBoot/src/main/resources/application.properties
@@ -42,7 +42,6 @@ spring.security.oauth2.client.registration.kakao.client-id=${KAKAO_CLIENT_ID}
 spring.security.oauth2.client.registration.kakao.client-secret=${KAKAO_CLIENT_SECRET}
 spring.security.oauth2.client.registration.kakao.client-authentication-method=client_secret_post
 spring.security.oauth2.client.registration.kakao.redirect-uri={baseUrl}/login/oauth2/code/{registrationId}
-spring.security.oauth2.client.registration.kakao.scope=profile_nickname
 spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code
 spring.security.oauth2.client.provider.kakao.authorization-uri=https://kauth.kakao.com/oauth/authorize
 spring.security.oauth2.client.provider.kakao.token-uri=https://kauth.kakao.com/oauth/token
@@ -60,3 +59,9 @@ server.servlet.context-path=/api
 
 # time setting - Korea:Seoul
 spring.jackson.time-zone=Asia/Seoul
+
+
+# JWT
+jwt.secret-key=${JWT_SECRET_KEY}
+jwt.access-token-expiration=1800000
+jwt.refresh-token-expiration=1209600000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,16 +78,24 @@ services:
   redis-session1:
     image: redis:7.2
     container_name: redis-session1
+    command: redis-server /usr/local/etc/redis/redis.conf
     ports:
       - "6380:6379"
+    volumes:
+      - redis-session1-data:/data
+      - ./redis/redis-session1.conf:/usr/local/etc/redis/redis.conf
     networks:
       - backend
 
   redis-session2:
     image: redis:7.2
     container_name: redis-session2
+    command: redis-server /usr/local/etc/redis/redis.conf
     ports:
       - "6381:6379"
+    volumes:
+      - redis-session2-data:/data
+      - ./redis/redis-session2.conf:/usr/local/etc/redis/redis.conf
     networks:
       - backend
 
@@ -123,7 +131,9 @@ services:
 
 volumes:
   mysql-data:
+  redis-session1-data:
+  redis-session2-data:
 
 networks:
   backend:
-    driver: bridge 
+    driver: bridge

--- a/redis/redis-session1.conf
+++ b/redis/redis-session1.conf
@@ -1,0 +1,23 @@
+# Redis 간단 설정 (JWT 토큰용)
+
+# 기본 연결 설정
+bind 0.0.0.0
+port 6379
+timeout 43200
+
+# 보안
+requirepass redis123
+
+# 메모리 (JWT 토큰이 많지 않으니 128MB로 설정)
+maxmemory 128mb
+maxmemory-policy allkeys-lru
+
+# 클라이언트 (동시 접속자 500명)
+maxclients 500
+
+# 데이터 보존 (AOF)
+appendonly yes
+appendfsync everysec
+
+# 로그 (에러만 출력)
+loglevel warning

--- a/redis/redis-session2.conf
+++ b/redis/redis-session2.conf
@@ -1,0 +1,23 @@
+# Redis 간단 설정 (JWT 토큰용)
+
+# 기본 연결 설정
+bind 0.0.0.0
+port 6379
+timeout 43200
+
+# 보안
+requirepass redis123
+
+# 메모리 (JWT 토큰이 많지 않으니 128MB로 설정)
+maxmemory 128mb
+maxmemory-policy allkeys-lru
+
+# 클라이언트 (500명)
+maxclients 500
+
+# 데이터 보존 (간단하게 AOF만)
+appendonly yes
+appendfsync everysec
+
+# 로그 (에러만 출력)
+loglevel warning


### PR DESCRIPTION

JWT 기반 인증 시스템을 위한 Redis 저장소 인프라를 구축하고 설정을 완료했습니다.

## ✨ Changes
### 🔧 Redis 설정 파일 추가
- **redis-session1.conf**: Primary JWT 토큰 저장소 설정
- **redis-session2.conf**: Backup JWT 토큰 저장소 설정

###  Docker Compose 업데이트  
- Redis 설정 파일 볼륨 마운트 추가
- 데이터 영속성을 위한 볼륨 설정
- 포트 매핑: redis-session1(6380), redis-session2(6381)

## ⚙️ Redis 설정 상세
| 설정 | 값 | 설명 |
|------|----|----|
| **메모리 제한** | 128MB | JWT 토큰 저장에 최적화 |
| **타임아웃** | 43,200초 (12시간) | 장기 세션 지원 |
| **최대 클라이언트** | 500개 | 동시 접속 처리 |
| **메모리 정책** | allkeys-lru | 메모리 부족 시 LRU 방식 삭제 |
| **데이터 영속성** | AOF (appendfsync everysec) | 1초마다 디스크 저장 |
| **보안** | requirepass redis123 | 비밀번호 인증 |

##  테스트 결과
```bash
# Redis 연결 테스트
✅ redis-session1: PONG
✅ redis-session2: PONG

# 설정 확인
✅ maxmemory: 134217728 (128MB)
✅ timeout: 43200 (12시간)