### PR TITLE
✨ [기능 추가] : BatchConfig 정의& 배치 패키지 분리 & 데이터베이스 코드 수정

### DIFF
--- a/SpringBoot/database/init.sql
+++ b/SpringBoot/database/init.sql
@@ -1,7 +1,7 @@
 -- 1. 사용자
 CREATE TABLE user
 (
-    id         BIGINT       NOT NULL COMMENT '고유번호',
+    id         BIGINT       NOT NULL AUTO_INCREMENT COMMENT '고유번호',
     user_id    VARCHAR(255) NOT NULL COMMENT '카카오에서 제공하는 id',
     created_at DATETIME     NOT NULL COMMENT '회원가입한 시간',
     PRIMARY KEY (id)
@@ -10,11 +10,11 @@ CREATE TABLE user
 -- 2. 뉴스
 CREATE TABLE news
 (
-    id           BIGINT       NOT NULL COMMENT '고유번호',
+    id           BIGINT       NOT NULL AUTO_INCREMENT COMMENT '고유번호',
     sections     VARCHAR(100) NOT NULL COMMENT '섹션',
     title        VARCHAR(255) NOT NULL COMMENT '기사의 제목',
     publisher    VARCHAR(255) NOT NULL COMMENT '발행처',
-    summary      VARCHAR(255) NOT NULL COMMENT '기사의 한줄요약',
+    summary      MEDIUMTEXT NOT NULL COMMENT '기사의 한줄요약',
     content_url  VARCHAR(255) NOT NULL COMMENT '기사의 url',
     published_at DATETIME     NOT NULL COMMENT '기사가 작성된 날짜',
     send         BOOLEAN      NOT NULL COMMENT '발송 여부',
@@ -24,7 +24,7 @@ CREATE TABLE news
 -- 3. 설정
 CREATE TABLE setting
 (
-    id            BIGINT   NOT NULL COMMENT '고유번호',
+    id            BIGINT   NOT NULL AUTO_INCREMENT COMMENT '고유번호',
     delivery_time DATETIME NOT NULL COMMENT '배송받고 싶은 시간',
     start_date    DATETIME NOT NULL COMMENT '배송받고 싶은 시작 기간',
     end_date      DATETIME NULL COMMENT '배송받고 싶은 종료 기간',
@@ -37,7 +37,7 @@ CREATE TABLE setting
 -- 4. 인증
 CREATE TABLE auth
 (
-    id                BIGINT       NOT NULL COMMENT '고유번호',
+    id                BIGINT       NOT NULL AUTO_INCREMENT COMMENT '고유번호',
     kakao_refresh_key VARCHAR(255) NOT NULL COMMENT '유효기간 2주',
     user_key          BIGINT       NOT NULL,
     PRIMARY KEY (id),
@@ -47,7 +47,7 @@ CREATE TABLE auth
 -- 5. 설정 제외 키워드
 CREATE TABLE setting_block_keyword
 (
-    id              BIGINT       NOT NULL COMMENT '고유번호',
+    id              BIGINT       NOT NULL AUTO_INCREMENT COMMENT '고유번호',
     setting_keyword VARCHAR(255) NOT NULL COMMENT '설정에 대해서만 적용되는 제외하는 키워드',
     setting_id      BIGINT       NOT NULL COMMENT '제외 키워드를 등록한 설정의 고유번호',
     PRIMARY KEY (id),
@@ -57,7 +57,7 @@ CREATE TABLE setting_block_keyword
 -- 6. 설정 키워드
 CREATE TABLE setting_keyword
 (
-    id              BIGINT       NOT NULL COMMENT '고유번호',
+    id              BIGINT       NOT NULL AUTO_INCREMENT COMMENT '고유번호',
     setting_keyword VARCHAR(255) NOT NULL COMMENT '뉴스를 받아보고 싶은 키워드',
     setting_id      BIGINT       NOT NULL COMMENT '키워드를 등록한 설정의 고유번호',
     PRIMARY KEY (id),
@@ -67,7 +67,7 @@ CREATE TABLE setting_keyword
 -- 7. 기사 발송 히스토리
 CREATE TABLE history
 (
-    id           BIGINT   NOT NULL COMMENT '고유번호',
+    id           BIGINT   NOT NULL AUTO_INCREMENT COMMENT '고유번호',
     published_at DATETIME NOT NULL COMMENT '기사가 발송된 날짜',
     setting_id   BIGINT   NOT NULL COMMENT '기사가 발송된 설정의 고유번호',
     news_id      BIGINT   NOT NULL COMMENT '기사가 발송된 기사의 고유번호',
@@ -98,7 +98,7 @@ CREATE TABLE days
 -- 10. 핫토픽
 CREATE TABLE hot_topic
 (
-    id         BIGINT       NOT NULL COMMENT '고유번호',
+    id         BIGINT       NOT NULL AUTO_INCREMENT COMMENT '고유번호',
     topic_rank BIGINT       NOT NULL COMMENT '핫토픽 순위',
     keyword    VARCHAR(255) NOT NULL COMMENT '핫토픽 키워드',
     topic_date DATETIME     NOT NULL COMMENT '해당날짜(계산일 기준 하루 전)',

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Global/Batch/BatchConfig.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Global/Batch/BatchConfig.java
@@ -1,4 +1,0 @@
-package Baemin.News_Deliver.Global.Batch;
-
-public class BatchConfig {
-}

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Global/Batch/JobRegistry.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Global/Batch/JobRegistry.java
@@ -1,4 +1,0 @@
-package Baemin.News_Deliver.Global.Batch;
-
-public class JobRegistry {
-}

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Global/Batch/listener.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Global/Batch/listener.java
@@ -1,4 +1,0 @@
-package Baemin.News_Deliver.Global.Batch;
-
-public class listener {
-}

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Global/Batch/processor.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Global/Batch/processor.java
@@ -1,4 +1,0 @@
-package Baemin.News_Deliver.Global.Batch;
-
-public class processor {
-}

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Global/Batch/reader.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Global/Batch/reader.java
@@ -1,4 +1,0 @@
-package Baemin.News_Deliver.Global.Batch;
-
-public class reader {
-}

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Global/Batch/repository/NewsRepository.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Global/Batch/repository/NewsRepository.java
@@ -1,7 +1,0 @@
-package Baemin.News_Deliver.Global.Batch.repository;
-
-import Baemin.News_Deliver.Global.Batch.entity.News;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface NewsRepository extends JpaRepository<News, Long> {
-}

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Global/Batch/step.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Global/Batch/step.java
@@ -1,4 +1,0 @@
-package Baemin.News_Deliver.Global.Batch;
-
-public class step {
-}

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Global/Batch/writer.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Global/Batch/writer.java
@@ -1,4 +1,0 @@
-package Baemin.News_Deliver.Global.Batch;
-
-public class writer {
-}

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/BatchConfig.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/BatchConfig.java
@@ -1,0 +1,86 @@
+package Baemin.News_Deliver.Global.News.Batch;
+
+import Baemin.News_Deliver.Global.News.Batch.JPAINSERT.dto.NewsItemDTO;
+import Baemin.News_Deliver.Global.News.Batch.JPAINSERT.entity.News;
+import Baemin.News_Deliver.Global.News.Batch.JPAINSERT.service.BatchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.support.ListItemReader;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableBatchProcessing
+public class BatchConfig {
+
+    @Bean
+    public Job newsDataSaveJob(JobRepository jobRepository, Step newsDataSaveStep) {
+        return new JobBuilder("newsDataSaveJob", jobRepository)
+                .start(newsDataSaveStep)
+                .build();
+    }
+
+    @Bean
+    public Step newsDataSaveStep(JobRepository jobRepository,
+                                 PlatformTransactionManager transactionManager,
+                                 ItemReader<NewsItemDTO> apiReader,
+                                 ItemProcessor<NewsItemDTO, News> newsProcessor,
+                                 ItemWriter<News> newsWriter) {
+
+        return new StepBuilder("newsDataSaveStep", jobRepository)
+                .<NewsItemDTO, News>chunk(10, transactionManager)  // 10개씩 처리
+                .reader(apiReader)
+                .processor(newsProcessor)
+                .writer(newsWriter)
+                .build();
+    }
+
+    @Bean
+    public ItemReader<NewsItemDTO> apiReader() {
+        // API에서 데이터를 모두 불러와서 ListItemReader로 반환
+        // ListItemReader가 이 데이터를 하나씩 읽어서 다음 단계로 전달
+
+        //예시) 이렇게 리스트를 ListItemReader로 변환해야함.
+        //List<NewsItemDTO> newsList = BatchService.fetchNews();
+        //return new ListItemReader<>(newsList);
+
+        //배치 코드 넣기
+
+        return null;
+    }
+
+    @Bean
+    public ItemProcessor<NewsItemDTO, News> newsProcessor() {
+        // 받아온 DTO를 엔티티로 변환하는 과정 (하나씩 처리)
+
+        //예시) 이렇게 dto를 뉴스 엔티티로 변환과정 필요함.
+        //return dto -> new News(dto.getTitle(), dto.getUrl());
+
+        //배치 코드 넣기
+
+        return null;
+    }
+
+    @Bean
+    public ItemWriter<News> newsWriter() {
+        // Chunk 단위로 모아진 News 엔티티들을 한번에 DB에 저장
+        //return items -> newsRepository.saveAll(items);
+
+        //jdbc로 바꿀 예정임.
+        //배치코드 넣기
+
+        return null;
+    }
+}

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/JPAINSERT/dto/NewsItemDTO.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/JPAINSERT/dto/NewsItemDTO.java
@@ -1,4 +1,4 @@
-package Baemin.News_Deliver.Global.Batch.dto;
+package Baemin.News_Deliver.Global.News.Batch.JPAINSERT.dto;
 
 import lombok.*;
 

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/JPAINSERT/dto/NewsResponseDTO.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/JPAINSERT/dto/NewsResponseDTO.java
@@ -1,4 +1,4 @@
-package Baemin.News_Deliver.Global.Batch.dto;
+package Baemin.News_Deliver.Global.News.Batch.JPAINSERT.dto;
 
 import lombok.*;
 

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/JPAINSERT/entity/News.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/JPAINSERT/entity/News.java
@@ -1,4 +1,4 @@
-package Baemin.News_Deliver.Global.Batch.entity;
+package Baemin.News_Deliver.Global.News.Batch.JPAINSERT.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
@@ -30,6 +30,7 @@ public class News {
     private LocalDateTime publishedAt;
 
     @Column(nullable = false)
+    @Builder.Default
     private Boolean send = false;
 
     @Column(nullable = false, length = 100)

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/JPAINSERT/repository/NewsRepository.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/JPAINSERT/repository/NewsRepository.java
@@ -1,0 +1,7 @@
+package Baemin.News_Deliver.Global.News.Batch.JPAINSERT.repository;
+
+import Baemin.News_Deliver.Global.News.Batch.JPAINSERT.entity.News;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NewsRepository extends JpaRepository<News, Long> {
+}

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/JPAINSERT/service/BatchCall.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/JPAINSERT/service/BatchCall.java
@@ -1,4 +1,4 @@
-package Baemin.News_Deliver.Global.Batch.service;
+package Baemin.News_Deliver.Global.News.Batch.JPAINSERT.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/JPAINSERT/service/BatchService.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/JPAINSERT/service/BatchService.java
@@ -1,9 +1,9 @@
-package Baemin.News_Deliver.Global.Batch.service;
+package Baemin.News_Deliver.Global.News.Batch.JPAINSERT.service;
 
-import Baemin.News_Deliver.Global.Batch.dto.NewsItemDTO;
-import Baemin.News_Deliver.Global.Batch.dto.NewsResponseDTO;
-import Baemin.News_Deliver.Global.Batch.entity.News;
-import Baemin.News_Deliver.Global.Batch.repository.NewsRepository;
+import Baemin.News_Deliver.Global.News.Batch.JPAINSERT.dto.NewsItemDTO;
+import Baemin.News_Deliver.Global.News.Batch.JPAINSERT.dto.NewsResponseDTO;
+import Baemin.News_Deliver.Global.News.Batch.JPAINSERT.entity.News;
+import Baemin.News_Deliver.Global.News.Batch.JPAINSERT.repository.NewsRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/JobRegistry.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/JobRegistry.java
@@ -1,0 +1,4 @@
+package Baemin.News_Deliver.Global.News.Batch;
+
+public class JobRegistry {
+}

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/listener.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/listener.java
@@ -1,0 +1,4 @@
+package Baemin.News_Deliver.Global.News.Batch;
+
+public class listener {
+}

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/processor.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/processor.java
@@ -1,0 +1,4 @@
+package Baemin.News_Deliver.Global.News.Batch;
+
+public class processor {
+}

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/reader.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/reader.java
@@ -1,0 +1,4 @@
+package Baemin.News_Deliver.Global.News.Batch;
+
+public class reader {
+}

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/step.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/step.java
@@ -1,0 +1,4 @@
+package Baemin.News_Deliver.Global.News.Batch;
+
+public class step {
+}

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/writer.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/writer.java
@@ -1,0 +1,4 @@
+package Baemin.News_Deliver.Global.News.Batch;
+
+public class writer {
+}


### PR DESCRIPTION
전체 과정
1. 데이터 AUTO_INCREMENT 추가함.
2. 패키지 분리 > 이전 원중님 코드와 배치를 분리
3. 롬북의 default 사용
4. 배치 컨피그 작성함

Spring Batch의 config 설정, ItemReader, ItemProcessor, ItemWriter를  연결하는 Step 및 Job을 설정했습니다.
API 혹은 수동 생성한 데이터 리스트를 읽어온 뒤, 가공 로직을 거쳐 DB에 저장되도록 하는 코드를 추가로 넣어야합니다.

🔨 작업 내역
ItemReader<NewsItemDTO>: 외부에서 받아온 뉴스 데이터를 리스트 형태로 읽음 > 코드에서 추가로 삽입할 부분
ItemProcessor<NewsItemDTO, News>: DTO를 엔티티로 변환 > 변환하여 넣어야함
ItemWriter<News>: JpaItemWriter 또는 JdbcBatchItemWriter로 DB에 저장 > jpa 에서 jdbc로 바꾸기로 했음

