### PR TITLE
✨ feat: Mypage 도메인 Setting 시스템 구현 - 사용자 맞춤형 뉴스 설정 기능

### DIFF
--- a/SpringBoot/build.gradle
+++ b/SpringBoot/build.gradle
@@ -79,6 +79,9 @@ dependencies {
 	// dev tools
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
+	// Jackson Datatype for Java 8 Date/Time API (뉴스 세팅에서 사용하는 임시 추가 파일 테스트 끝난 후 삭제 할 예정)
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
 }
 
 dependencyManagement {

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Mypage/Controller/TestSettingController.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Mypage/Controller/TestSettingController.java
@@ -1,0 +1,166 @@
+package Baemin.News_Deliver.Domain.Mypage.Controller;
+
+import Baemin.News_Deliver.Domain.Auth.Entity.User;
+import Baemin.News_Deliver.Domain.Auth.Repository.UserRepository;
+import Baemin.News_Deliver.Domain.Mypage.Entity.Days;
+import Baemin.News_Deliver.Domain.Mypage.Entity.Setting;
+import Baemin.News_Deliver.Domain.Mypage.Entity.SettingBlockKeyword;
+import Baemin.News_Deliver.Domain.Mypage.Entity.SettingKeyword;
+import Baemin.News_Deliver.Domain.Mypage.Repository.DaysRepository;
+import Baemin.News_Deliver.Domain.Mypage.Repository.SettingBlockKeywordRepository;
+import Baemin.News_Deliver.Domain.Mypage.Repository.SettingKeywordRepository;
+import Baemin.News_Deliver.Domain.Mypage.Repository.SettingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+@RestController
+@RequestMapping("/test")
+@RequiredArgsConstructor
+public class TestSettingController {
+
+    private final SettingRepository settingRepository;
+    private final UserRepository userRepository;
+    private final DaysRepository daysRepository;
+    private final SettingKeywordRepository settingKeywordRepository;
+    private final SettingBlockKeywordRepository settingBlockKeywordRepository;  // 현재 미작동
+
+    // Setting 생성 테스트
+    @PostMapping("/setting")
+    public String createSetting(@RequestParam String kakaoId) {
+        // 1. User 조회 (kakaoId로 찾기)
+        User user = userRepository.findByKakaoId(kakaoId)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다: " + kakaoId));
+
+        // 2. Setting 생성
+        Setting setting = Setting.builder()
+                .deliveryTime(LocalTime.of(14, 30))
+                .startDate(LocalDateTime.now())
+                .endDate(null)
+                .isDeleted(false)
+                .user(user)
+                .build();
+
+        // 3. 저장
+        Setting saved = settingRepository.save(setting);
+
+        return "Setting 생성 완료! ID: " + saved.getId() + ", User: " + user.getKakaoId();
+    }
+
+    // Setting 조회 테스트 - Days + Keywords + BlockKeywords(금요일 오전 기준 미포함) 포함
+    @GetMapping("/setting")
+    public String getSettings(@RequestParam String kakaoId) {
+        User user = userRepository.findByKakaoId(kakaoId)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다: " + kakaoId));
+
+        List<Setting> settings = settingRepository.findByUser(user);
+
+        StringBuilder result = new StringBuilder();
+        result.append("찾은 설정 개수: ").append(settings.size()).append("\n");
+
+        for (Setting setting : settings) {
+            result.append("ID: ").append(setting.getId())
+                    .append(", 시간: ").append(setting.getDeliveryTime())
+                    .append(", 시작일: ").append(setting.getStartDate())
+                    .append(", Days 개수: ").append(setting.getDays().size())
+                    .append(", Keywords 개수: ").append(setting.getKeywords().size())
+                    .append(", Block Keywords 개수: ").append(setting.getBlockKeywords().size())  // 추가!
+                    .append("\n");
+
+            // Days 목록 표시
+            for (Days day : setting.getDays()) {
+                result.append("  - 요일: ").append(day.getDeliveryDays()).append("\n");
+            }
+
+            // Keywords 목록 표시
+            for (SettingKeyword keyword : setting.getKeywords()) {
+                result.append("  - 키워드: ").append(keyword.getSettingKeyword()).append("\n");
+            }
+
+            // Block Keywords 목록 표시 (새로 추가!)
+            for (SettingBlockKeyword blockKeyword : setting.getBlockKeywords()) {
+                result.append("  - 제외 키워드: ").append(blockKeyword.getSettingKeyword()).append("\n");
+            }
+        }
+
+        return result.toString();
+    }
+
+    // User 테이블 확인용 추가
+    @GetMapping("/users")
+    public String getAllUsers() {
+        List<User> users = userRepository.findAll();
+        StringBuilder result = new StringBuilder();
+        result.append("사용자 수: ").append(users.size()).append("\n");
+
+        for (User user : users) {
+            result.append("ID: ").append(user.getId())
+                    .append(", KakaoID: ").append(user.getKakaoId())
+                    .append(", 생성일: ").append(user.getCreatedAt())
+                    .append("\n");
+        }
+
+        return result.toString();
+    }
+
+    // Days 생성 테스트
+    @PostMapping("/days")
+    public String createDays(@RequestParam Long settingId, @RequestParam String day) {
+        // 1. Setting 조회
+        Setting setting = settingRepository.findById(settingId)
+                .orElseThrow(() -> new RuntimeException("설정을 찾을 수 없습니다"));
+
+        // 2. Days 생성
+        Days days = Days.builder()
+                .deliveryDays(day)
+                .setting(setting)
+                .build();
+
+        // 3. 저장
+        Days saved = daysRepository.save(days);
+
+        return "Days 생성 완료! ID: " + saved.getId() + ", 요일: " + saved.getDeliveryDays();
+    }
+
+    // SettingKeyword 생성 테스트
+    @PostMapping("/keyword")
+    public String createKeyword(@RequestParam Long settingId, @RequestParam String keyword) {
+        // 1. Setting 조회
+        Setting setting = settingRepository.findById(settingId)
+                .orElseThrow(() -> new RuntimeException("설정을 찾을 수 없습니다"));
+
+        // 2. SettingKeyword 생성
+        SettingKeyword settingKeyword = SettingKeyword.builder()
+                .settingKeyword(keyword)
+                .setting(setting)
+                .build();
+
+        // 3. 저장
+        SettingKeyword saved = settingKeywordRepository.save(settingKeyword);
+
+        return "Keyword 생성 완료! ID: " + saved.getId() + ", 키워드: " + saved.getSettingKeyword();
+    }
+
+    // SettingBlockKeyword 생성 테스트
+    // 블랙키워드 작성중-    '-"  작성시 헤더 오류
+    @PostMapping("/blockKeyword")
+    public String createBlockKeyword(@RequestParam Long settingId, @RequestParam String keyword) {
+        // 1. Setting 조회
+        Setting setting = settingRepository.findById(settingId)
+                .orElseThrow(() -> new RuntimeException("설정을 찾을 수 없습니다"));
+
+        // 2. SettingBlockKeyword 생성
+        SettingBlockKeyword blockKeyword = SettingBlockKeyword.builder()
+                .settingKeyword(keyword)
+                .setting(setting)
+                .build();
+
+        // 3. 저장
+        SettingBlockKeyword saved = settingBlockKeywordRepository.save(blockKeyword);
+
+        return "Block Keyword 생성 완료! ID: " + saved.getId() + ", 제외 키워드: " + saved.getSettingKeyword();
+    }
+}

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Mypage/Entity/Days.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Mypage/Entity/Days.java
@@ -1,0 +1,32 @@
+package Baemin.News_Deliver.Domain.Mypage.Entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "days")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Days {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "delivery_days", nullable = false)
+    private String deliveryDays;  // "MON", "TUE", "WED" 등
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "setting_id", nullable = false)
+    private Setting setting;
+
+    @Builder
+    public Days(String deliveryDays, Setting setting) {
+        this.deliveryDays = deliveryDays;
+        this.setting = setting;
+    }
+}

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Mypage/Entity/Setting.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Mypage/Entity/Setting.java
@@ -1,0 +1,63 @@
+package Baemin.News_Deliver.Domain.Mypage.Entity;
+
+import Baemin.News_Deliver.Domain.Auth.Entity.User;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+@Entity
+@Table(name = "setting")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Setting {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "delivery_time", nullable = false)
+    private LocalTime deliveryTime;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDateTime startDate;
+
+    @Column(name = "end_date")
+    private LocalDateTime endDate;
+
+    @Column(name = "is_deleted")
+    private Boolean isDeleted;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @OneToMany(mappedBy = "setting", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+    @JsonIgnore
+    private List<Days> days;
+
+    @OneToMany(mappedBy = "setting", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+    @JsonIgnore
+    private List<SettingKeyword> keywords;
+
+    @OneToMany(mappedBy = "setting", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+    @JsonIgnore
+    private List<SettingBlockKeyword> blockKeywords;
+
+    @Builder
+    public Setting(LocalTime deliveryTime, LocalDateTime startDate,
+                   LocalDateTime endDate, Boolean isDeleted, User user) {
+        this.deliveryTime = deliveryTime;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.isDeleted = isDeleted;
+        this.user = user;
+    }
+}

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Mypage/Entity/SettingBlockKeyword.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Mypage/Entity/SettingBlockKeyword.java
@@ -1,0 +1,33 @@
+package Baemin.News_Deliver.Domain.Mypage.Entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "setting_block_keyword")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+//현재 미개발
+public class SettingBlockKeyword {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "setting_keyword", nullable = false)
+    private String settingKeyword;  // 제외할 키워드
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "setting_id", nullable = false)
+    private Setting setting;
+
+    @Builder
+    public SettingBlockKeyword(String settingKeyword, Setting setting) {
+        this.settingKeyword = settingKeyword;
+        this.setting = setting;
+    }
+}

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Mypage/Entity/SettingKeyword.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Mypage/Entity/SettingKeyword.java
@@ -1,0 +1,32 @@
+package Baemin.News_Deliver.Domain.Mypage.Entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "setting_keyword")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SettingKeyword {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "setting_keyword", nullable = false)
+    private String settingKeyword;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "setting_id", nullable = false)
+    private Setting setting;
+
+    @Builder
+    public SettingKeyword(String settingKeyword, Setting setting) {
+        this.settingKeyword = settingKeyword;
+        this.setting = setting;
+    }
+}

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Mypage/Repository/DaysRepository.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Mypage/Repository/DaysRepository.java
@@ -1,0 +1,24 @@
+package Baemin.News_Deliver.Domain.Mypage.Repository;
+
+import Baemin.News_Deliver.Domain.Mypage.Entity.Days;
+import Baemin.News_Deliver.Domain.Mypage.Entity.Setting;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface DaysRepository extends JpaRepository<Days, Long> {
+
+    // 특정 설정의 요일 목록 조회
+    List<Days> findBySetting(Setting setting);
+
+    // 특정 설정의 요일 개수 조회
+    long countBySetting(Setting setting);
+
+    // 특정 설정의 모든 요일 삭제
+    void deleteBySetting(Setting setting);
+
+    // 특정 요일에 해당하는 모든 설정 조회 (스케줄러에서 사용  /  다른 분들과 상의 후 변경)
+    List<Days> findByDeliveryDays(String deliveryDays);
+}

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Mypage/Repository/SettingBlockKeywordRepository.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Mypage/Repository/SettingBlockKeywordRepository.java
@@ -1,0 +1,24 @@
+package Baemin.News_Deliver.Domain.Mypage.Repository;
+
+import Baemin.News_Deliver.Domain.Mypage.Entity.Setting;
+import Baemin.News_Deliver.Domain.Mypage.Entity.SettingBlockKeyword;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface SettingBlockKeywordRepository extends JpaRepository<SettingBlockKeyword, Long> {
+
+    // 특정 설정의 제외 키워드 목록 조회
+    List<SettingBlockKeyword> findBySetting(Setting setting);
+
+    // 특정 설정의 제외 키워드 개수 조회
+    long countBySetting(Setting setting);
+
+    // 특정 설정의 모든 제외 키워드 삭제
+    void deleteBySetting(Setting setting);
+
+    // 특정 제외 키워드를 가진 모든 설정 조회
+    List<SettingBlockKeyword> findBySettingKeyword(String settingKeyword);
+}

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Mypage/Repository/SettingKeywordRepository.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Mypage/Repository/SettingKeywordRepository.java
@@ -1,0 +1,24 @@
+package Baemin.News_Deliver.Domain.Mypage.Repository;
+
+import Baemin.News_Deliver.Domain.Mypage.Entity.Setting;
+import Baemin.News_Deliver.Domain.Mypage.Entity.SettingKeyword;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface SettingKeywordRepository extends JpaRepository<SettingKeyword, Long> {
+
+    // 특정 설정의 키워드 목록 조회
+    List<SettingKeyword> findBySetting(Setting setting);
+
+    // 특정 설정의 키워드 개수 조회
+    long countBySetting(Setting setting);
+
+    // 특정 설정의 모든 키워드 삭제
+    void deleteBySetting(Setting setting);
+
+    // 특정 키워드를 가진 모든 설정 조회 (스케줄러에서 사용  따른 분들과 토의후 변경)
+    List<SettingKeyword> findBySettingKeyword(String settingKeyword);
+}

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Mypage/Repository/SettingRepository.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Mypage/Repository/SettingRepository.java
@@ -1,0 +1,21 @@
+package Baemin.News_Deliver.Domain.Mypage.Repository;
+
+import Baemin.News_Deliver.Domain.Auth.Entity.User;
+import Baemin.News_Deliver.Domain.Mypage.Entity.Setting;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface SettingRepository extends JpaRepository<Setting, Long> {
+
+    // 사용자별 설정 목록 조회
+    List<Setting> findByUser(User user);
+
+    // 사용자별 설정 개수 조회 (최대 3개 제한 체크용)
+    long countByUser(User user);
+
+    // 사용자별 설정 존재 여부 확인
+    boolean existsByUser(User user);
+}

--- a/SpringBoot/src/main/resources/application.properties
+++ b/SpringBoot/src/main/resources/application.properties
@@ -68,5 +68,5 @@ deepsearch.api.key=${DEEPSEARCH_API_KEY}
 spring.elasticsearch.uris=http://${ELASTICSEARCH_SERVER}:${ELASTICSEARCH_PORT}
 
 
-# Forward headers ?? ?? ??
+# Forward headers Check
 server.forward-headers-strategy=framework


### PR DESCRIPTION
## 작업 내용  (현재 테스트)
사용자별 뉴스 수신 설정을 관리하는 Mypage 도메인의 Setting 시스템을 구현했습니다.

## ✨ 주요 기능
- **Setting 엔티티**: 사용자별 뉴스 수신 시간, 기간 설정
- **Days 엔티티**: 요일별 수신 설정 (MON, TUE, WED 등)
- **SettingKeyword 엔티티**: 관심 키워드 관리
- **SettingBlockKeyword 엔티티**: 제외 키워드 관리 (블랙리스트)

## 🏗️ 구현 상세
### 엔티티 구조
- Setting (1) : Days (N) - 요일 설정
- Setting (1) : SettingKeyword (N) - 관심 키워드
- Setting (1) : SettingBlockKeyword (N) - 제외 키워드
- User (1) : Setting (N) - 사용자당 최대 3개 설정 예정

### Repository 계층
- 각 엔티티별 Repository 구현
- 연관관계 조회 메서드 추가
- CASCADE 설정으로 데이터 무결성 보장

## 🧪 테스트
- TestSettingController로 전체 CRUD 검증 완료
- 1:N 연관관계 동작 확인
- JSON 직렬화 문제 해결 (@JsonIgnore 적용)

## 🔧 기술적 개선사항
- `jackson-datatype-jsr310` 의존성 추가
- LocalTime, LocalDateTime JSON 직렬화 지원

## 📋 체크리스트
- [x] 엔티티 설계 및 구현
- [x] Repository 계층 구현
- [x] 연관관계 설정 및 테스트
- [x] CRUD 동작 검증
- [ ] Service 계층 구현 (다음 작업)
- [ ] 실제 API 컨트롤러 구현 (다음 작업)
