### PR TITLE
 ♻️ Refactor/auth error Auth 도메인 ErrorCode 추가 (6xx번대 15개)

### DIFF
--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Auth/Controller/AuthController.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Auth/Controller/AuthController.java
@@ -1,6 +1,8 @@
 package Baemin.News_Deliver.Domain.Auth.Controller;
 
 import Baemin.News_Deliver.Domain.Auth.Service.AuthService;
+import Baemin.News_Deliver.Domain.Auth.dto.TokenResponse;
+import Baemin.News_Deliver.Domain.Auth.dto.UserResponse;
 import Baemin.News_Deliver.Global.ResponseObject.ApiResponseWrapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,7 +24,7 @@ public class AuthController {
      * 토큰 갱신 API
      */
     @PostMapping("/refresh")
-    public ResponseEntity<ApiResponseWrapper<AuthService.TokenResponse>> refreshToken(
+    public ResponseEntity<ApiResponseWrapper<TokenResponse>> refreshToken(
             @RequestBody Map<String, String> request) {
 
         String refreshToken = request.get("refreshToken");
@@ -32,7 +34,7 @@ public class AuthController {
                     .body(new ApiResponseWrapper<>(null, "Refresh token이 필요합니다"));
         }
 
-        AuthService.TokenResponse tokenResponse = authService.refreshToken(refreshToken);
+        TokenResponse tokenResponse = authService.refreshToken(refreshToken);
 
         return ResponseEntity.ok(
                 new ApiResponseWrapper<>(tokenResponse, "토큰 갱신 성공")
@@ -62,7 +64,7 @@ public class AuthController {
      * 현재 사용자 정보 조회 API
      */
     @GetMapping("/me")
-    public ResponseEntity<ApiResponseWrapper<AuthService.UserResponse>> getCurrentUser(
+    public ResponseEntity<ApiResponseWrapper<UserResponse>> getCurrentUser(
             Authentication authentication) {
 
         if (authentication == null) {
@@ -71,7 +73,7 @@ public class AuthController {
         }
 
         String kakaoId = authentication.getName();
-        AuthService.UserResponse userResponse = authService.getCurrentUser(kakaoId);
+        UserResponse userResponse = authService.getCurrentUser(kakaoId);
 
         return ResponseEntity.ok(
                 new ApiResponseWrapper<>(userResponse, "사용자 정보 조회 성공")

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Auth/Exception/AuthException.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Auth/Exception/AuthException.java
@@ -8,4 +8,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AuthException extends RuntimeException {
     private final ErrorCode errorcode;
+
+    @Override
+    public String getMessage() {
+        return errorcode.getMessage();
+    }
 }

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Auth/Service/AuthService.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Auth/Service/AuthService.java
@@ -1,7 +1,11 @@
 package Baemin.News_Deliver.Domain.Auth.Service;
 
 import Baemin.News_Deliver.Domain.Auth.Entity.User;
+import Baemin.News_Deliver.Domain.Auth.Exception.AuthException;
 import Baemin.News_Deliver.Domain.Auth.Repository.UserRepository;
+import Baemin.News_Deliver.Domain.Auth.dto.TokenResponse;
+import Baemin.News_Deliver.Domain.Auth.dto.UserResponse;
+import Baemin.News_Deliver.Global.Exception.ErrorCode;
 import Baemin.News_Deliver.Global.JWT.JwtTokenProvider;
 import Baemin.News_Deliver.Global.Redis.RedisService;
 import lombok.RequiredArgsConstructor;
@@ -24,8 +28,7 @@ public class AuthService {
      */
     @Transactional(readOnly = true)
     public User findByKakaoId(String kakaoId) {
-        return userRepository.findByKakaoId(kakaoId)
-                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다"));
+        return userRepository.findByKakaoId(kakaoId).orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
     }
 
     /**
@@ -43,7 +46,7 @@ public class AuthService {
         try {
             // 1. Refresh Token 유효성 검증
             if (!jwtTokenProvider.validateToken(refreshToken)) {
-                throw new RuntimeException("리프레시 토큰이 유효하지 않습니다");
+                throw new AuthException(ErrorCode.REFRESH_TOKEN_INVALID);
             }
 
             // 2. Refresh Token에서 kakaoId 추출
@@ -51,12 +54,12 @@ public class AuthService {
 
             // 3. Redis에서 저장된 Refresh Token과 비교 검증
             if (!redisService.validateRefreshToken(kakaoId, refreshToken)) {
-                throw new RuntimeException("리프레시 토큰이 유효하지 않습니다");
+                throw new AuthException(ErrorCode.REFRESH_TOKEN_INVALID);
             }
 
             // 4. 사용자 존재 확인
             if (!existsByKakaoId(kakaoId)) {
-                throw new RuntimeException("사용자를 찾을 수 없습니다");
+                throw new AuthException(ErrorCode.USER_NOT_FOUND);
             }
 
             // 5. 새로운 토큰들 생성
@@ -70,9 +73,13 @@ public class AuthService {
             log.info("토큰 갱신 성공: kakaoId = {}", kakaoId);
             return new TokenResponse(newAccessToken, newRefreshToken, "Bearer", 1800);
 
+        } catch (AuthException e) {
+            log.error("토큰 갱신 실패: kakaoId = {}, errorCode = {}",
+                    jwtTokenProvider.getKakaoIdFromToken(refreshToken), e.getErrorcode().getErrorCode());
+            throw e; // AuthException은 그대로 재던지기
         } catch (Exception e) {
-            log.error("토큰 갱신 실패: {}", e.getMessage());
-            throw new RuntimeException("토큰 저장 중 오류가 발생했습니다");
+            log.error("토큰 갱신 중 예상치 못한 오류: {}", e.getMessage());
+            throw new AuthException(ErrorCode.TOKEN_STORAGE_FAILED);
         }
     }
 
@@ -86,7 +93,7 @@ public class AuthService {
             log.info("로그아웃 성공: kakaoId = {}", kakaoId);
         } catch (Exception e) {
             log.error("로그아웃 실패: kakaoId = {}, error = {}", kakaoId, e.getMessage());
-            throw new RuntimeException("토큰 저장 중 오류가 발생했습니다");
+            throw new AuthException(ErrorCode.TOKEN_STORAGE_FAILED);
         }
     }
 
@@ -97,37 +104,5 @@ public class AuthService {
     public UserResponse getCurrentUser(String kakaoId) {
         User user = findByKakaoId(kakaoId);
         return new UserResponse(user.getId(), user.getKakaoId(), user.getCreatedAt());
-    }
-
-    /**
-     * 토큰 응답 DTO
-     */
-    public static class TokenResponse {
-        public final String accessToken;
-        public final String refreshToken;
-        public final String tokenType;
-        public final long expiresIn;
-
-        public TokenResponse(String accessToken, String refreshToken, String tokenType, long expiresIn) {
-            this.accessToken = accessToken;
-            this.refreshToken = refreshToken;
-            this.tokenType = tokenType;
-            this.expiresIn = expiresIn;
-        }
-    }
-
-    /**
-     * 사용자 응답 DTO
-     */
-    public static class UserResponse {
-        public final Long id;
-        public final String kakaoId;
-        public final java.time.LocalDateTime createdAt;
-
-        public UserResponse(Long id, String kakaoId, java.time.LocalDateTime createdAt) {
-            this.id = id;
-            this.kakaoId = kakaoId;
-            this.createdAt = createdAt;
-        }
     }
 }

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Auth/dto/TokenResponse.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Auth/dto/TokenResponse.java
@@ -1,0 +1,16 @@
+package Baemin.News_Deliver.Domain.Auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * JWT 토큰 응답 DTO
+ */
+@Getter
+@AllArgsConstructor
+public class TokenResponse {
+    private final String accessToken;
+    private final String refreshToken;
+    private final String tokenType;
+    private final long expiresIn;
+}

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Auth/dto/UserResponse.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Auth/dto/UserResponse.java
@@ -1,0 +1,17 @@
+package Baemin.News_Deliver.Domain.Auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 사용자 정보 응답 DTO
+ */
+@Getter
+@AllArgsConstructor
+public class UserResponse {
+    private final Long id;
+    private final String kakaoId;
+    private final LocalDateTime createdAt;
+}

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Global/Exception/ErrorCode.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Global/Exception/ErrorCode.java
@@ -11,9 +11,35 @@ public enum ErrorCode {
     /* Global 예외 0xx */
     DATABASE_ERROR("GLOBAL_ERROR_001",
             "데이터 베이스 오류",
-            HttpStatus.INTERNAL_SERVER_ERROR);
+            HttpStatus.INTERNAL_SERVER_ERROR),
 
-    /* Auth 예외 : 6xx */
+    /* Auth 예외: 6xx */
+    // 사용자 관련 (601~610)
+    USER_NOT_FOUND("AUTH_ERROR_601", "사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND),
+    USER_CREATION_FAILED("AUTH_ERROR_602", "사용자 생성에 실패했습니다", HttpStatus.INTERNAL_SERVER_ERROR),
+    USER_UNAUTHORIZED("AUTH_ERROR_603", "사용자 권한이 없습니다", HttpStatus.FORBIDDEN),
+
+    // JWT 토큰 관련 (611~620)
+    INVALID_TOKEN("AUTH_ERROR_611", "유효하지 않은 토큰입니다", HttpStatus.UNAUTHORIZED),
+    EXPIRED_TOKEN("AUTH_ERROR_612", "만료된 토큰입니다", HttpStatus.UNAUTHORIZED),
+    TOKEN_REFRESH_FAILED("AUTH_ERROR_613", "토큰 갱신에 실패했습니다", HttpStatus.UNAUTHORIZED),
+    TOKEN_STORAGE_FAILED("AUTH_ERROR_614", "토큰 저장 중 오류가 발생했습니다", HttpStatus.INTERNAL_SERVER_ERROR),
+    TOKEN_NOT_PROVIDED("AUTH_ERROR_615", "토큰이 제공되지 않았습니다", HttpStatus.BAD_REQUEST),
+    REFRESH_TOKEN_INVALID("AUTH_ERROR_616", "리프레시 토큰이 유효하지 않습니다", HttpStatus.UNAUTHORIZED),
+
+    // 인증/로그인 관련 (621~630)
+    LOGIN_FAILED("AUTH_ERROR_621", "로그인에 실패했습니다", HttpStatus.UNAUTHORIZED),
+    LOGOUT_FAILED("AUTH_ERROR_622", "로그아웃에 실패했습니다", HttpStatus.INTERNAL_SERVER_ERROR),
+    AUTHENTICATION_REQUIRED("AUTH_ERROR_623", "인증이 필요합니다", HttpStatus.UNAUTHORIZED),
+    AUTHENTICATION_FAILED("AUTH_ERROR_624", "인증에 실패했습니다", HttpStatus.UNAUTHORIZED),
+
+    // OAuth2/카카오 관련 (631~640)
+    KAKAO_LOGIN_FAILED("AUTH_ERROR_631", "카카오 로그인에 실패했습니다", HttpStatus.UNAUTHORIZED),
+    KAKAO_TOKEN_REFRESH_FAILED("AUTH_ERROR_632", "카카오 토큰 갱신에 실패했습니다", HttpStatus.UNAUTHORIZED),
+    KAKAO_TOKEN_INVALID("AUTH_ERROR_633", "카카오 토큰이 유효하지 않습니다", HttpStatus.UNAUTHORIZED),
+    OAUTH2_PROVIDER_NOT_SUPPORTED("AUTH_ERROR_634", "지원하지 않는 OAuth2 제공자입니다", HttpStatus.BAD_REQUEST),
+    OAUTH2_PROCESS_FAILED("AUTH_ERROR_635", "OAuth2 처리 중 오류가 발생했습니다", HttpStatus.INTERNAL_SERVER_ERROR);
+
     /* HotTopic 예외 : 7xx */
     /* Kakao 예외 : 8xx */
     /* Mypage 예외 : 9xx */

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Global/JWT/JwtTokenProvider.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Global/JWT/JwtTokenProvider.java
@@ -66,15 +66,15 @@ public class JwtTokenProvider {
             parseClaims(token);
             return true;
         } catch (SignatureException e) {
-            log.error("Invalid JWT signature: {}", e.getMessage());
+            log.error("잘못된 JWT 서명: {}", e.getMessage());
         } catch (MalformedJwtException e) {
-            log.error("Invalid JWT token: {}", e.getMessage());
+            log.error("잘못된 형식의 JWT 토큰: {}", e.getMessage());
         } catch (ExpiredJwtException e) {
-            log.error("JWT token is expired: {}", e.getMessage());
+            log.error("만료된 JWT 토큰: {}", e.getMessage());
         } catch (UnsupportedJwtException e) {
-            log.error("JWT token is unsupported: {}", e.getMessage());
+            log.error("지원되지 않는 JWT 토큰: {}", e.getMessage());
         } catch (IllegalArgumentException e) {
-            log.error("JWT claims string is empty: {}", e.getMessage());
+            log.error("JWT claims가 비어있음: {}", e.getMessage());
         }
         return false;
     }


### PR DESCRIPTION
##  변경 사항
- Auth 도메인 ErrorCode 추가 (6xx번대 15개)
- RuntimeException → AuthException 표준화
- DTO 클래스 분리 (TokenResponse, UserResponse)
- JWT 로그 메시지 한국어 개선

##  주요 개선점
- 구체적인 에러코드로 클라이언트 디버깅 향상
- 일관된 예외 처리 구조
- DTO 재사용성 향상

##  테스트
- [ ] 기존 API 동작 확인
- [ ] 에러 응답 형태 확인
- [ ] 로그 메시지 확인

##  Breaking Changes
- 없음 (기존 API 호환성 유지)