### PR TITLE
✨ [기능추가] 엘라스틱 서치로 검색한 키워드로 카톡 메시지 전송완료

### DIFF
--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Kakao/controller/KakaoTestController.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Kakao/controller/KakaoTestController.java
@@ -5,6 +5,7 @@ import Baemin.News_Deliver.Domain.Auth.Repository.AuthRepository;
 import Baemin.News_Deliver.Domain.Kakao.service.KakaoMessageService;
 import Baemin.News_Deliver.Domain.Kakao.service.KakaoNewsService;
 import Baemin.News_Deliver.Global.Kakao.KakaoTokenProvider;
+import Baemin.News_Deliver.Global.News.ElasticSearch.dto.NewsEsDocument;
 import Baemin.News_Deliver.Global.ResponseObject.ApiResponseWrapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,37 +16,43 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.Map;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 @Slf4j
+@RequestMapping("/kakao")
 public class KakaoTestController {
 
     private final KakaoMessageService kakaoMessageService;
-    private final KakaoTokenProvider provider;
-    private final KakaoNewsService newsService;
-    private final AuthRepository authRepository;
+    private final KakaoNewsService newsSearchService;
 
     /**
      * 카카오톡 나에게 보내기 메시지 전송 메서드
      */
-    @GetMapping("/kakao/send-message")
-    @ResponseBody
+    @GetMapping("/send-message")
     public ResponseEntity<ApiResponseWrapper<String>> sendMessage() {
 
         try {
             boolean success = kakaoMessageService.sendKakaoMessage();
 
             if (success) {
-                return ResponseEntity.ok(new ApiResponseWrapper<>("SUCCESS", "메시지 전송 성공"));
+                return ResponseEntity.ok(new ApiResponseWrapper<>("SUCCESS", "뉴스 메시지 전송 성공"));
             } else {
                 return ResponseEntity.internalServerError()
-                        .body(new ApiResponseWrapper<>(null, "메시지 전송 실패"));
+                        .body(new ApiResponseWrapper<>(null, "뉴스 메시지 전송 실패"));
             }
+
         } catch (Exception e) {
             log.error("메시지 전송 중 오류 발생: ", e);
             return ResponseEntity.internalServerError()
                     .body(new ApiResponseWrapper<>(null, "메시지 전송 중 오류 발생: " + e.getMessage()));
         }
+    }
+
+    @GetMapping("/search-news")
+    public ResponseEntity<List<NewsEsDocument>> searchNews(
+            @RequestParam String keyword,
+            @RequestParam(required = false, defaultValue = "") String blockKeyword) {
+        return ResponseEntity.ok(newsSearchService.searchNews(keyword, blockKeyword));
     }
 
 }

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Kakao/dto/HistoryDTO.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Kakao/dto/HistoryDTO.java
@@ -1,5 +1,6 @@
 package Baemin.News_Deliver.Domain.Kakao.dto;
 
+import jakarta.persistence.Column;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -14,4 +15,7 @@ public class HistoryDTO {
     private LocalDateTime published_at;
     private String setting_id;
     private String news_id;
+    private String settingKeyword;
+    private String blockKeyword;
+
 }

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Kakao/entity/History.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Kakao/entity/History.java
@@ -18,6 +18,12 @@ public class History {
     @Column(name = "published_at", nullable = false)
     private LocalDateTime publishedAt;
 
+    @Column(name = "setting_keyword", nullable = false)
+    private String settingKeyword;
+
+    @Column(name = "block_keyword", nullable = true)
+    private String blockKeyword;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "setting_id", nullable = false)
     private Setting setting;
@@ -25,6 +31,8 @@ public class History {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "news_id", nullable = false)
     private News news;
+
+
 
 
 }

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/controller/BatchController.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/controller/BatchController.java
@@ -18,7 +18,7 @@ public class BatchController {
     private final Job newsDataSaveJob;
     private final BatchService batchService;
 
-    @GetMapping("/run-batch") // ✅ GET 방식으로 변경
+        @GetMapping("/run-batch") // ✅ GET 방식으로 변경
     public ResponseEntity<String> runBatch() {
         return batchService.runBatch();
     }


### PR DESCRIPTION
히스토리 entity, dto 수정함


`package Baemin.News_Deliver.Domain.Kakao.dto;

import jakarta.persistence.Column;
import lombok.*;

import java.time.LocalDateTime;

@Getter
@Setter
@NoArgsConstructor
@AllArgsConstructor
@Builder
public class HistoryDTO {
    private String id;
    private LocalDateTime published_at;
    private String setting_id;
    private String news_id;
    private String settingKeyword;
    private String blockKeyword;

}
`


`package Baemin.News_Deliver.Domain.Kakao.entity;

import Baemin.News_Deliver.Domain.Mypage.Entity.Setting;
import Baemin.News_Deliver.Global.News.JPAINSERT.entity.News;
import jakarta.persistence.*;
import lombok.Getter;

import java.time.LocalDateTime;

@Entity
@Table(name = "history")
@Getter
public class History {
    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;

    @Column(name = "published_at", nullable = false)
    private LocalDateTime publishedAt;

    @Column(name = "setting_keyword", nullable = false)
    private String settingKeyword;

    @Column(name = "block_keyword", nullable = true)
    private String blockKeyword;

    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "setting_id", nullable = false)
    private Setting setting;

    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "news_id", nullable = false)
    private News news;




}
`


 엘라스틱 서치로 검색한 키워드로 카톡 메시지 전송완료 