### PR TITLE
🔧 [구성 변경] HTTPS ALB 설정 및 CORS 도메인 추가

### DIFF
--- a/SpringBoot/src/main/java/Baemin/News_Deliver/SecurityConfig.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/SecurityConfig.java
@@ -125,14 +125,16 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        // 프로덕션 환경에서는 특정 도메인만 허용
+
         configuration.setAllowedOriginPatterns(Arrays.asList(
                 "http://localhost:3000",           // 개발용 React
                 "http://localhost:3001",           // 개발용 React (포트 변경시)
                 "http://localhost:5173",           // 개발용 React
-                "https://merry-crepe-479d93.netlify.app", // 프로토타입 배포 URL
+                "https://likelionnews.click",      // 프론트엔드 메인 도메인
+                "https://www.likelionnews.click",  // 프론트엔드 www 도메인
+                "https://*.amplifyapp.com",        // Amplify 기본 도메인
+                "https://merry-crepe-479d93.netlify.app", // 기존 프로토타입
                 "http://43.201.27.98"             // AWS EC2 IP
-
         ));
 
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));

--- a/SpringBoot/src/main/resources/application.properties
+++ b/SpringBoot/src/main/resources/application.properties
@@ -44,7 +44,7 @@ spring.ai.openai.chat.options.model=gpt-3.5-turbo
 spring.security.oauth2.client.registration.kakao.client-id=${KAKAO_CLIENT_ID}
 spring.security.oauth2.client.registration.kakao.client-secret=${KAKAO_CLIENT_SECRET}
 spring.security.oauth2.client.registration.kakao.client-authentication-method=client_secret_post
-spring.security.oauth2.client.registration.kakao.redirect-uri=http://43.201.27.98:8080/login/oauth2/code/kakao
+spring.security.oauth2.client.registration.kakao.redirect-uri=https://api.likelionnews.click/login/oauth2/code/kakao
 spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code
 spring.security.oauth2.client.provider.kakao.authorization-uri=https://kauth.kakao.com/oauth/authorize
 spring.security.oauth2.client.provider.kakao.token-uri=https://kauth.kakao.com/oauth/token
@@ -84,6 +84,8 @@ spring.elasticsearch.uris=http://${ELASTICSEARCH_SERVER}:${ELASTICSEARCH_PORT}
 
 # Forward headers Check
 server.forward-headers-strategy=framework
+server.tomcat.redirect-context-root=false
+server.tomcat.use-relative-redirects=true
 
 # prometheus
 management.endpoints.web.exposure.include=health,info,prometheus


### PR DESCRIPTION
# 🔧 HTTPS ALB 설정 및 프로덕션 도메인 전환

##  개요
AWS ALB(Application Load Balancer)를 통한 HTTPS 전환 및 프로덕션 도메인 설정을 위한 백엔드 구성 변경입니다.

##  변경 사항

###  인프라 변경사항
- **ALB 프록시 헤더 처리 설정 추가** - ALB 뒤에서 정상적인 리다이렉트 동작을 위함
- **카카오 OAuth 리다이렉트 URI HTTPS로 변경** - 프로덕션 도메인 `api.likelionnews.click` 사용
- **CORS 정책에 프로덕션 도메인 추가** - 프론트엔드 HTTPS 도메인 허용

###  수정된 파일들
- `SpringBoot/src/main/resources/application.properties`
- `SpringBoot/src/main/java/Baemin/News_Deliver/SecurityConfig.java`

##  상세 변경내용

### application.properties 설정 추가
```properties
# HTTPS ALB 프록시 설정
server.forward-headers-strategy=framework
server.tomcat.redirect-context-root=false
server.tomcat.use-relative-redirects=true

# 카카오 OAuth HTTPS 리다이렉트 URI
spring.security.oauth2.client.registration.kakao.redirect-uri=https://api.likelionnews.click/login/oauth2/code/kakao
```

### SecurityConfig.java - CORS 도메인 추가
```java
configuration.setAllowedOriginPatterns(Arrays.asList(
    "http://localhost:3000",           // 개발용
    "http://localhost:3001",           // 개발용  
    "http://localhost:5173",           // 개발용
    "https://likelionnews.click",      // 🆕 프론트엔드 메인 도메인
    "https://www.likelionnews.click",  // 🆕 프론트엔드 www 도메인
    "https://*.amplifyapp.com",        // 🆕 AWS Amplify 도메인 패턴
    "https://merry-crepe-479d93.netlify.app", // 기존 프로토타입 유지
    "http://43.201.27.98"             // 기존 EC2 IP 유지
));
```

## 아키텍처 플로우

### 변경 전 (HTTP)
```
클라이언트 → EC2:8080 (HTTP)
```

### 변경 후 (HTTPS)
```
클라이언트 → ALB:443 (HTTPS) → EC2:8080 (HTTP)
         → ALB:80 (HTTP) → 301 리다이렉트 → HTTPS
```

##  도메인 구조
- **프론트엔드**: `likelionnews.click` (AWS Amplify)
- **백엔드 API**: `api.likelionnews.click` (AWS ALB → EC2)
- **SSL 인증서**: AWS ACM으로 관리

##  테스트 체크리스트

###  배포 전 테스트
- [ ] 코드 컴파일 확인
- [ ] 설정 파일 문법 검증
- [ ] Docker 빌드 테스트

###  배포 후 테스트
- [ ] HTTPS API 접속 테스트: `https://api.likelionnews.click/api/auth/status`
- [ ] HTTP → HTTPS 리다이렉트 확인: `http://api.likelionnews.click`
- [ ] ALB 대상 그룹 헬스체크 상태 확인
- [ ] 카카오 OAuth 로그인 플로우 테스트
- [ ] CORS 정책 동작 확인

###  테스트 명령어
```bash
# HTTPS API 테스트
curl -I https://api.likelionnews.click/api/auth/status

# HTTP 리다이렉트 테스트  
curl -I http://api.likelionnews.click/api/auth/status

# CORS 테스트 (브라우저 콘솔에서)
fetch('https://api.likelionnews.click/api/auth/status', {mode: 'cors'})
```

##  롤백 계획
문제 발생 시 즉시 이전 커밋으로 롤백 가능:
```bash
git reset --hard HEAD~1
git push --force origin master
docker-compose down && docker-compose up -d --build
```

##  관련 인프라 구성
- **AWS ALB**: `likelionnews-alb` 
- **대상 그룹**: `likelionnews-backend`
- **ACM 인증서**: `api.likelionnews.click`
- **Route 53**: A 레코드 `api.likelionnews.click` → ALB

## 사전 완료 작업
- [ ] ALB 생성 및 설정 완료
- [ ] ACM SSL 인증서 발급 완료
- [ ] Route 53 DNS 설정 완료
- [ ] EC2 보안 그룹 수정 완료
- [ ] 카카오 개발자 콘솔 리다이렉트 URI 추가

##  머지 후 작업 예정
- [ ] 카카오 개발자 콘솔에서 새 리다이렉트 URI 추가
- [ ] 프론트엔드 환경 변수 업데이트 (`REACT_APP_API_URL`)
- [ ] AWS Amplify 프론트엔드 배포 및 도메인 연결

##  기대 효과
- ✅ **보안 강화**: HTTPS 암호화 통신
- ✅ **SEO 개선**: HTTPS는 검색 엔진 랭킹 요소
- ✅ **사용자 신뢰도**: 브라우저 보안 경고 제거
- ✅ **확장성**: ALB를 통한 로드 밸런싱 기반 마련
- ✅ **프로덕션 준비**: 실제 도메인을 사용한 서비스 운영


4. **호환성 확인**: 기존 개발 환경 설정이 유지되는지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 프론트엔드 메인 도메인, www 서브도메인, Amplify 앱 도메인 패턴을 허용된 CORS 오리진 목록에 추가했습니다.

* **버그 수정**
  * OAuth2 카카오 클라이언트 리디렉트 URI를 도메인 기반 HTTPS 주소로 변경했습니다.

* **기타 작업**
  * Tomcat 리디렉트 관련 설정이 추가되어 리디렉트 동작이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->