### PR TITLE
💡 리다이렉트:  https://likelionnews.click/?error=true  주석 추가 localhost 추가

### DIFF
--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Global/OAuth2/OAuth2LoginSuccessHandler.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Global/OAuth2/OAuth2LoginSuccessHandler.java
@@ -238,10 +238,14 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
             String tokenJson = objectMapper.writeValueAsString(tokenData);
             String encodedToken = java.net.URLEncoder.encode(tokenJson, "UTF-8");
 
-            return "/?token=" + encodedToken;
+            return "https://likelionnews.click/?token=" + encodedToken;
+//              로컬용
+//            return "http://localhost:5173/?token=" + encodedToken;
         } catch (Exception e) {
             log.error("리다이렉트 URL 생성 실패: {}", e.getMessage());
-            return "/?error=true";
+            return "https://likelionnews.click/?error=true";
+//            로컬용
+//            return "/?error=true";
         }
     }
 


### PR DESCRIPTION
💡 리다이렉트:  https://likelionnews.click/?error=true  주석 추가 localhost 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * OAuth2 로그인 성공 후 리디렉션 URL이 절대 경로(`https://likelionnews.click`)로 변경되어, 인증 후 올바른 페이지로 이동됩니다.  
  * 로그인 오류 발생 시에도 절대 경로를 사용하여 에러 페이지로 이동합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->