### PR TITLE
🐛 [버그 수정] & ⚡️[성능 향상]  : Setting 객체 저장 시 영속성 문제 해결 & 페이지네이션 반환 DTO 수정 

### DIFF
--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Mypage/service/SettingService.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Mypage/service/SettingService.java
@@ -75,6 +75,16 @@ public class SettingService {
                 .user(user)
                 .build();
 
+        /**
+         * What : Setting 객체 저장 코드
+         * Why : Setting 데이터 저장 없이,  자식 관계인 SettingKeyword는 저장되는 상황 발생 -> Error 발생
+         * When : 2025-07-21
+         * Who : 류성열
+         *
+         * Then : Setting 객체를 먼저 저장, 영속 상태로 만들어 오류 해결 시도
+         */
+        settingRepository.save(setting);
+
         saveSettingKeyword(settingDTO, setting);
         saveBlockKeyword(settingDTO, setting);
         saveDays(settingDTO, setting);

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/SubServices/MoreNews/Controller/MoreNewsController.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/SubServices/MoreNews/Controller/MoreNewsController.java
@@ -1,6 +1,7 @@
 package Baemin.News_Deliver.Domain.SubServices.MoreNews.Controller;
 
 import Baemin.News_Deliver.Domain.SubServices.MoreNews.DTO.GroupedNewsHistoryResponse;
+import Baemin.News_Deliver.Domain.SubServices.MoreNews.DTO.PageResponse;
 import Baemin.News_Deliver.Domain.SubServices.MoreNews.Service.MoreNewsService;
 import Baemin.News_Deliver.Global.News.ElasticSearch.dto.NewsEsDocument;
 import Baemin.News_Deliver.Global.ResponseObject.ApiResponseWrapper;
@@ -9,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
@@ -60,12 +62,13 @@ public class MoreNewsController {
                     @ApiResponse(responseCode = "500",description = "서버 내부 오류 발생")
             })
     @GetMapping("")
-    public ResponseEntity<ApiResponseWrapper<List<GroupedNewsHistoryResponse>>> getNewsHistoryList(
+    public ResponseEntity<ApiResponseWrapper<PageResponse<GroupedNewsHistoryResponse>>> getNewsHistoryList(
+            Authentication authentication,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "3") int size
     ) {
         // 내 히스토리 조회하기 서비스 레이어 호출
-        List<GroupedNewsHistoryResponse> groupedList = moreNewsService.getGroupedNewsHistory(page, size);
+        PageResponse<GroupedNewsHistoryResponse> groupedList  = moreNewsService.getGroupedNewsHistory(page, size, authentication);
 
         return ResponseEntity.ok(new ApiResponseWrapper<>(groupedList, "히스토리가 성공적으로 조회되었습니다."));
     }

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/SubServices/MoreNews/DTO/PageResponse.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/SubServices/MoreNews/DTO/PageResponse.java
@@ -1,0 +1,18 @@
+package Baemin.News_Deliver.Domain.SubServices.MoreNews.DTO;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PageResponse<T> {
+    private List<T> data;
+    private int currentPage;
+    private int pageSize;
+    private int totalPages;
+    private long totalElements;
+}

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/SubServices/MoreNews/Service/MoreNewsService.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/SubServices/MoreNews/Service/MoreNewsService.java
@@ -1,5 +1,6 @@
 package Baemin.News_Deliver.Domain.SubServices.MoreNews.Service;
 
+import Baemin.News_Deliver.Domain.Auth.Service.AuthService;
 import Baemin.News_Deliver.Domain.Kakao.entity.History;
 import Baemin.News_Deliver.Domain.Kakao.repository.HistoryRepository;
 import Baemin.News_Deliver.Domain.SubServices.Exception.SubServicesException;
@@ -7,6 +8,7 @@ import Baemin.News_Deliver.Domain.SubServices.FeedBack.Entity.Feedback;
 import Baemin.News_Deliver.Domain.SubServices.FeedBack.Repository.FeedbackRepository;
 import Baemin.News_Deliver.Domain.SubServices.MoreNews.DTO.GroupedNewsHistoryResponse;
 import Baemin.News_Deliver.Domain.SubServices.MoreNews.DTO.NewsHistoryResponse;
+import Baemin.News_Deliver.Domain.SubServices.MoreNews.DTO.PageResponse;
 import Baemin.News_Deliver.Global.Exception.ErrorCode;
 import Baemin.News_Deliver.Global.News.ElasticSearch.dto.NewsEsDocument;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
@@ -18,6 +20,7 @@ import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.json.JsonData;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
@@ -34,6 +37,7 @@ public class MoreNewsService {
     private final HistoryRepository historyRepository;
     private final FeedbackRepository feedbackRepository;
     private final ElasticsearchClient client;
+    private final AuthService authService;
 
     // ======================= 뉴스 추가 검색 메서드 =========================
 
@@ -153,30 +157,35 @@ public class MoreNewsService {
 
     // ======================= 내 히스토리 조회하기 메서드 =========================
 
-
     /**
-     * 내 히스토리 조회하기 메서드 (페이지 네이션 적용)
+     * 내 히스토리 조회하기 메서드 Ver2.0
      *
-     * @param page 시작 페이지
+     * Updated
+     * Why : 프론트 레이어에서 페이지 네이셔닝을 위한 정보 부족
+     * How : 반환 DTO에 페이지네이션 정보 추가
+     * When : 2025-07-21
+     * Who : 류성열
+     *
+     * @param page 현재 페이지
      * @param size 페이지 사이즈
-     * @return 페이지 네이션이 적용된 히스토리
+     * @return 페이지 정보 + 페이지 데이터
      */
-    public List<GroupedNewsHistoryResponse> getGroupedNewsHistory(int page, int size) {
-        Long userId = 1L;
+    public PageResponse<GroupedNewsHistoryResponse> getGroupedNewsHistory(int page, int size, Authentication authentication) {
 
-        // 1. 모든 히스토리 조회
+        // 인증 객체에서 카카오 ID 추출
+        String kakaoId = authentication.getName();
+        Long userId = authService.findByKakaoId(kakaoId).getId();
+
         List<History> allHistories = historyRepository.findAllBySetting_User_Id(userId);
 
-        // 2. 히스토리 ID 수집 → Feedback 일괄 조회
         List<Long> historyIds = allHistories.stream()
                 .map(History::getId)
-                .collect(Collectors.toList());
+                .toList();
 
         Map<Long, Feedback> feedbackMap = feedbackRepository.findAllById(historyIds)
                 .stream()
                 .collect(Collectors.toMap(fb -> fb.getHistory().getId(), fb -> fb));
 
-        // 3. 그룹핑: settingId + publishedAt(HOUR)
         Map<String, List<History>> grouped = allHistories.stream()
                 .collect(Collectors.groupingBy(h -> {
                     Long settingId = h.getSetting().getId();
@@ -184,7 +193,6 @@ public class MoreNewsService {
                     return settingId + "_" + truncatedPublishedAt;
                 }));
 
-        // 4. DTO 변환
         List<GroupedNewsHistoryResponse> groupedList = grouped.entrySet().stream()
                 .map(entry -> {
                     List<History> histories = entry.getValue();
@@ -206,17 +214,90 @@ public class MoreNewsService {
                             .build();
                 })
                 .sorted(Comparator.comparing(GroupedNewsHistoryResponse::getPublishedAt).reversed())
-                .collect(Collectors.toList());
+                .toList();
 
-        // 5. 페이지네이션
+        int total = groupedList.size();
         int fromIndex = page * size;
-        int toIndex = Math.min(fromIndex + size, groupedList.size());
+        int toIndex = Math.min(fromIndex + size, total);
 
-        if (fromIndex >= groupedList.size()) {
-            return Collections.emptyList();
-        }
+        List<GroupedNewsHistoryResponse> paginated = fromIndex >= total
+                ? Collections.emptyList()
+                : groupedList.subList(fromIndex, toIndex);
 
-        return groupedList.subList(fromIndex, toIndex);
+        return PageResponse.<GroupedNewsHistoryResponse>builder()
+                .data(paginated)
+                .currentPage(page)
+                .pageSize(size)
+                .totalPages((int) Math.ceil((double) total / size))
+                .totalElements(total)
+                .build();
     }
+
+    // ======================= Deprecated =========================
+
+    /**
+     * 내 히스토리 조회하기 메서드 (페이지 네이션 적용)
+     *
+     * @param page 시작 페이지
+     * @param size 페이지 사이즈
+     * @return 페이지 네이션이 적용된 히스토리
+     */
+//    public PageResponse<GroupedNewsHistoryResponse> getGroupedNewsHistory(int page, int size) {
+//        Long userId = 1L;
+//
+//        // 1. 모든 히스토리 조회
+//        List<History> allHistories = historyRepository.findAllBySetting_User_Id(userId);
+//
+//        // 2. 히스토리 ID 수집 → Feedback 일괄 조회
+//        List<Long> historyIds = allHistories.stream()
+//                .map(History::getId)
+//                .collect(Collectors.toList());
+//
+//        Map<Long, Feedback> feedbackMap = feedbackRepository.findAllById(historyIds)
+//                .stream()
+//                .collect(Collectors.toMap(fb -> fb.getHistory().getId(), fb -> fb));
+//
+//        // 3. 그룹핑: settingId + publishedAt(HOUR)
+//        Map<String, List<History>> grouped = allHistories.stream()
+//                .collect(Collectors.groupingBy(h -> {
+//                    Long settingId = h.getSetting().getId();
+//                    LocalDateTime truncatedPublishedAt = h.getPublishedAt().truncatedTo(ChronoUnit.HOURS);
+//                    return settingId + "_" + truncatedPublishedAt;
+//                }));
+//
+//        // 4. DTO 변환
+//        List<GroupedNewsHistoryResponse> groupedList = grouped.entrySet().stream()
+//                .map(entry -> {
+//                    List<History> histories = entry.getValue();
+//                    History any = histories.get(0);
+//
+//                    List<NewsHistoryResponse> newsResponses = histories.stream()
+//                            .map(history -> {
+//                                Feedback feedback = feedbackMap.get(history.getId());
+//                                return NewsHistoryResponse.from(history, feedback);
+//                            })
+//                            .toList();
+//
+//                    return GroupedNewsHistoryResponse.builder()
+//                            .settingId(any.getSetting().getId())
+//                            .publishedAt(any.getPublishedAt().truncatedTo(ChronoUnit.HOURS))
+//                            .settingKeyword(any.getSettingKeyword())
+//                            .blockKeyword(any.getBlockKeyword())
+//                            .newsList(newsResponses)
+//                            .build();
+//                })
+//                .sorted(Comparator.comparing(GroupedNewsHistoryResponse::getPublishedAt).reversed())
+//                .collect(Collectors.toList());
+//
+//        // 5. 페이지네이션
+//        int fromIndex = page * size;
+//        int toIndex = Math.min(fromIndex + size, groupedList.size());
+//
+//        if (fromIndex >= groupedList.size()) {
+//            return Collections.emptyList();
+//        }
+//
+//        return groupedList.subList(fromIndex, toIndex);
+//    }
 
 }


### PR DESCRIPTION
🐛 [버그 수정] : Setting 저장 시, 자식 객체의 비영속 부모 객체 참조 문제 해결
⚡️[성능 향상] :  Mypage > 히스토리 조회 시 페이지네이션 조회를 위한 추가 데이터 반환

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 뉴스 히스토리 조회 시 페이징 정보(현재 페이지, 전체 페이지, 전체 항목 수 등)를 포함한 응답 구조가 추가되었습니다.

* **버그 수정**
  * 설정 저장 시 부모 엔티티가 먼저 저장되어 하위 엔티티 저장 오류가 해결되었습니다.

* **리팩터링**
  * 뉴스 히스토리 조회 API 및 서비스가 인증 기반 사용자 정보와 페이징을 지원하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->