### PR TITLE
♻️[리팩토링] : 테스트 컨트롤러 엔드포인트 변경

### DIFF
--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/HotTopic/controller/HotTopicAdminController.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/HotTopic/controller/HotTopicAdminController.java
@@ -1,0 +1,40 @@
+package Baemin.News_Deliver.Domain.HotTopic.controller;
+
+import Baemin.News_Deliver.Domain.HotTopic.service.HotTopicService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class HotTopicAdminController {
+
+    private final HotTopicService hotTopicService;
+
+    /**
+     * 어제의 핫토픽 키워드를 Elasticsearch에서 추출 후 DB에 저장
+     *
+     * <p>내부 테스트용이거나 추후 스케줄러로 대체될 예정입니다.</p>
+     *
+     * @throws IOException Elasticsearch 통신 오류
+     */
+    @Operation(
+            summary = "어제의 핫토픽 추출 및 저장 (관리용)",
+            description = "Elasticsearch에서 어제의 인기 키워드를 추출하고 DB에 저장합니다. (스케줄러 예정)"
+    )
+    @ApiResponses(@ApiResponse(responseCode = "204", description = "설정 삭제 성공"))
+    @GetMapping("/api/admin/hottopic")
+    public ResponseEntity<Void> saveHotTopic() throws IOException {
+        hotTopicService.getAndSaveHotTopic();
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/HotTopic/controller/HotTopicController.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/HotTopic/controller/HotTopicController.java
@@ -69,20 +69,4 @@ public class HotTopicController {
         return ResponseEntity.ok(newsEsDocumentList);
     }
 
-    /**
-     * 어제의 핫토픽 키워드를 Elasticsearch에서 추출 후 DB에 저장
-     *
-     * <p>내부 테스트용이거나 추후 스케줄러로 대체될 예정입니다.</p>
-     *
-     * @throws IOException Elasticsearch 통신 오류
-     */
-    @Operation(
-            summary = "어제의 핫토픽 추출 및 저장 (관리용)",
-            description = "Elasticsearch에서 어제의 인기 키워드를 추출하고 DB에 저장합니다. (스케줄러 예정)"
-    )
-    @ApiResponse(responseCode = "200", description = "저장 완료")
-    @GetMapping("/savehottopic")
-    public void saveHotTopic() throws IOException {
-        hotTopicService.getAndSaveHotTopic();
-    }
 }

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Mypage/Controller/SettingController.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Mypage/Controller/SettingController.java
@@ -33,12 +33,6 @@ public class SettingController {
     private final SettingService settingService;
     private final AuthService authService;
 
-    /**
-     * 현재 사용자의 모든 설정 조회
-     *
-     * @param authentication 인증 객체 (JWT 토큰에서 추출)
-     * @return 설정 리스트
-     */
     @GetMapping
     @Operation(summary = "내 뉴스 설정 목록 조회", description = "현재 로그인한 사용자의 모든 뉴스 설정을 조회합니다.")
     @SecurityRequirement(name = "Bearer Authentication")
@@ -48,21 +42,10 @@ public class SettingController {
             @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
     })
     public ResponseEntity<List<SettingDTO>> getAllSetting(Authentication authentication) {
-        try {
-            // 인증 객체에서 카카오 ID 추출
-            String kakaoId = authentication.getName();
-
-            // 카카오 ID로 사용자 조회 (인증 실패 예외 처리)
-            Long userId = authService.findByKakaoId(kakaoId).getId();
-
-            List<SettingDTO> settings = settingService.getAllSettingsByUserId(userId);
-            return ResponseEntity.ok(settings);
-
-        } catch (Exception e) {
-            log.error("설정 목록 조회 실패: kakaoId={}, error={}",
-                    authentication.getName(), e.getMessage());
-            throw new SettingException(ErrorCode.USER_NOT_FOUND);
-        }
+        String kakaoId = authentication.getName();
+        Long userId = authService.findByKakaoId(kakaoId).getId();
+        List<SettingDTO> settings = settingService.getAllSettingsByUserId(userId);
+        return ResponseEntity.ok(settings);
     }
 
     /**
@@ -83,22 +66,11 @@ public class SettingController {
     })
     public ResponseEntity<Long> saveSetting(@RequestBody SettingDTO settingDTO,
                                             Authentication authentication) {
-        try {
-            // 인증 객체에서 카카오 ID 추출
-            String kakaoId = authentication.getName();
-
-            // 카카오 ID로 사용자 조회하여 DTO에 설정 (인증 실패 예외 처리)
-            Long userId = authService.findByKakaoId(kakaoId).getId();
-            settingDTO.setUserId(userId);
-
-            Long settingId = settingService.saveSetting(settingDTO);
-            return ResponseEntity.ok(settingId);
-
-        } catch (Exception e) {
-            log.error("설정 저장 실패: kakaoId={}, error={}",
-                    authentication.getName(), e.getMessage());
-            throw new SettingException(ErrorCode.SETTING_CREATION_FAILED);
-        }
+        String kakaoId = authentication.getName();
+        Long userId = authService.findByKakaoId(kakaoId).getId();
+        settingDTO.setUserId(userId);
+        Long settingId = settingService.saveSetting(settingDTO);
+        return ResponseEntity.ok(settingId);
     }
 
     /**
@@ -120,22 +92,11 @@ public class SettingController {
     })
     public ResponseEntity<Void> updateSetting(@RequestBody SettingDTO settingDTO,
                                               Authentication authentication) {
-        try {
-            // 인증 객체에서 카카오 ID 추출
-            String kakaoId = authentication.getName();
-
-            // 카카오 ID로 사용자 조회하여 DTO에 설정 (인증 실패 예외 처리)
-            Long userId = authService.findByKakaoId(kakaoId).getId();
-            settingDTO.setUserId(userId);
-
-            settingService.updateSetting(settingDTO);
-            return ResponseEntity.noContent().build();
-
-        } catch (Exception e) {
-            log.error("설정 수정 실패: kakaoId={}, error={}",
-                    authentication.getName(), e.getMessage());
-            throw new SettingException(ErrorCode.SETTING_UPDATE_FAILED);
-        }
+        String kakaoId = authentication.getName();
+        Long userId = authService.findByKakaoId(kakaoId).getId();
+        settingDTO.setUserId(userId);
+        settingService.updateSetting(settingDTO);
+        return ResponseEntity.noContent().build();
     }
 
     /**
@@ -156,10 +117,8 @@ public class SettingController {
     })
     public ResponseEntity<Void> deleteSetting(@PathVariable("id") Long id,
                                               Authentication authentication) {
-
         String kakaoId = authentication.getName();
         Long userId = authService.findByKakaoId(kakaoId).getId();
-
         settingService.deleteSetting(id, userId);
         return ResponseEntity.noContent().build();
     }

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/controller/BatchController.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/controller/BatchController.java
@@ -1,11 +1,12 @@
 package Baemin.News_Deliver.Global.News.Batch.controller;
 
 import Baemin.News_Deliver.Global.News.Batch.service.BatchService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobParametersInvalidException;
-import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
 import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
 import org.springframework.batch.core.repository.JobRestartException;
@@ -18,12 +19,23 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class BatchController {
 
-    private final JobLauncher jobLauncher;
-    private final Job newsDataSaveJob;
     private final BatchService batchService;
 
-    @GetMapping("/run-batch") // ✅ GET 방식으로 변경
-    public ResponseEntity<String> runBatch() throws JobInstanceAlreadyCompleteException, JobExecutionAlreadyRunningException, JobParametersInvalidException, JobRestartException {
-        return batchService.runBatch();
+    @Operation(
+            summary = "배치 작업 실행",
+            description = "관리자 권한으로 뉴스 데이터를 배치 처리합니다. 실행 중이면 예외가 발생할 수 있습니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "성공적으로 배치 작업이 실행됨"),
+            @ApiResponse(responseCode = "500", description = "배치 실행 중 오류 발생 (Job이 이미 실행 중이거나 완료됨)")
+    })
+    @GetMapping("/api/admin/batch")
+    public ResponseEntity<Void> runBatch()
+            throws JobInstanceAlreadyCompleteException,
+            JobExecutionAlreadyRunningException,
+            JobParametersInvalidException,
+            JobRestartException {
+        batchService.runBatch();
+        return ResponseEntity.noContent().build();
     }
 }

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/service/BatchService.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/service/BatchService.java
@@ -57,10 +57,8 @@ public class BatchService {
      *
      * 각 섹션에 대해 하나의 Job을 실행하며,
      * JobParameter로 섹션명과 현재 시간(`time`)을 함께 전달합니다.
-     *
-     * @return ResponseEntity 응답 (성공 시 200 OK, 실패 시 500)
      */
-    public ResponseEntity<String> runBatch() throws JobInstanceAlreadyCompleteException, JobExecutionAlreadyRunningException, JobParametersInvalidException, JobRestartException {
+    public void runBatch() throws JobInstanceAlreadyCompleteException, JobExecutionAlreadyRunningException, JobParametersInvalidException, JobRestartException {
         long totalStart = System.currentTimeMillis(); // 전체 시작 시간
 
         for (String section : sections) {
@@ -78,8 +76,6 @@ public class BatchService {
 
         long totalEnd = System.currentTimeMillis(); // 전체 끝 시간
         log.info("✅ 전체 섹션 배치 소요 시간: {} ms", (totalEnd - totalStart));
-
-        return ResponseEntity.ok("뉴스 Batch 서비스 성공");
     }
 
 }

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/service/BatchService.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/Batch/service/BatchService.java
@@ -74,6 +74,8 @@ public class BatchService {
             jobLauncher.run(newsDataSaveJob, params);
         }
 
+        intermediateBatchRedisService.flushIntermediateBatchKeys();
+
         long totalEnd = System.currentTimeMillis(); // 전체 끝 시간
         log.info("✅ 전체 섹션 배치 소요 시간: {} ms", (totalEnd - totalStart));
     }

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/ElasticSearch/configuration/ElasticsearchClientConfig.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/ElasticSearch/configuration/ElasticsearchClientConfig.java
@@ -48,8 +48,7 @@ public class ElasticsearchClientConfig {
         // HTTP 기반 Low-level 클라이언트 구성
         RestClient restClient = RestClient.builder(
                 new HttpHost("elasticsearch", 9200)
-                // 성열 로컬용 임시 Host
-                //new HttpHost("localhost", 9200)
+                //FIXME : ElasticSearch 수정 시 수정할 것
         ).build();
 
         // LocalDateTime 직렬화 지원 및 ISO 포맷 지정

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/ElasticSearch/controller/EsCallController.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Global/News/ElasticSearch/controller/EsCallController.java
@@ -3,9 +3,10 @@ package Baemin.News_Deliver.Global.News.ElasticSearch.controller;
 import Baemin.News_Deliver.Global.News.ElasticSearch.service.NewsEsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
@@ -23,7 +24,6 @@ import java.io.IOException;
  */
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/elasticsearch")
 public class EsCallController {
 
     private final NewsEsService newsEsService;
@@ -40,9 +40,10 @@ public class EsCallController {
             summary = "[관리자/테스트] 전날 뉴스 색인 실행",
             description = "전날 DB에서 뉴스 데이터를 불러와 섹션별로 Elasticsearch에 bulk 색인합니다. 테스트용 엔드포인트입니다."
     )
-    @ApiResponse(responseCode = "200", description = "색인 작업이 정상적으로 시작됨")
-    @GetMapping("/bulk")
-    public void bulk() throws IOException {
+    @ApiResponses(@ApiResponse(responseCode = "204", description = "설정 삭제 성공"))
+    @GetMapping("/api/admin/elasticsearch")
+    public ResponseEntity<Void> bulk() throws IOException {
         newsEsService.esBulkService();
+        return ResponseEntity.noContent().build();
     }
 }

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Global/NewsMonitoring/Config/NewsMonitoringConfig.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Global/NewsMonitoring/Config/NewsMonitoringConfig.java
@@ -15,6 +15,8 @@ import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.database.BeanPropertyItemSqlParameterSourceProvider;
+import org.springframework.batch.item.database.JdbcBatchItemWriter;
 import org.springframework.batch.item.support.ListItemReader;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -145,21 +147,18 @@ public class NewsMonitoringConfig {
     @Bean
     public ItemWriter<News> newsWriter_Monitoring(javax.sql.DataSource dataSource) {
 
-        return items -> {
-            log.info("[임시 로직] 실제 저장하지는 않지만, newsWriter_Monitoring 기능 정상 작동 - 전체 뉴스 개수: {}", items.size());
-        };
 
         /* 실제 DB 저장 로직 */
-//        JdbcBatchItemWriter<News> writer = new JdbcBatchItemWriter<>();
-//        writer.setDataSource(dataSource);
-//        writer.setSql("""
-//        INSERT INTO news (title, summary, content_url, published_at, send, sections, publisher)
-//        VALUES (:title, :summary, :contentUrl, :publishedAt, :send, :sections, :publisher)
-//    """);
-//
-//        writer.setItemSqlParameterSourceProvider(new BeanPropertyItemSqlParameterSourceProvider<>());
-//        writer.afterPropertiesSet(); // 설정 검증 필수
-//
-//        return writer;
+        JdbcBatchItemWriter<News> writer = new JdbcBatchItemWriter<>();
+        writer.setDataSource(dataSource);
+        writer.setSql("""
+        INSERT INTO news (title, summary, content_url, published_at, send, sections, publisher)
+        VALUES (:title, :summary, :contentUrl, :publishedAt, :send, :sections, :publisher)
+    """);
+
+        writer.setItemSqlParameterSourceProvider(new BeanPropertyItemSqlParameterSourceProvider<>());
+        writer.afterPropertiesSet(); // 설정 검증 필수
+
+        return writer;
     }
 }

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/SecurityConfig.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/SecurityConfig.java
@@ -60,9 +60,8 @@ public class SecurityConfig {
                         .requestMatchers("/actuator/health").permitAll()
 
                         //  테스트용 엔드포인트
-                        .requestMatchers("/run-batch").permitAll()
-                        .requestMatchers("/elasticsearch/**").permitAll()
                         .requestMatchers("/monitoring/test/**").permitAll()
+                        .requestMatchers("/api/admin/**").permitAll()
 
                         //  HotTopic 공개 API (로그인 없이도 조회 가능)
                         .requestMatchers("/api/hottopic/**").permitAll()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 어드민용 핫토픽 저장 API 엔드포인트가 추가되었습니다.

* **버그 수정**
  * 기존 핫토픽 저장 엔드포인트가 제거되었습니다.

* **기능 개선**
  * 배치 실행, 엘라스틱서치 색인 등 어드민 관련 엔드포인트의 URL이 `/api/admin/**`로 통합 변경되었습니다.
  * 배치 실행, 엘라스틱서치 색인 엔드포인트의 응답 코드가 204 No Content로 통일되었습니다.
  * 배치 서비스 실행 시 중간 데이터 캐시가 자동으로 삭제됩니다.
  * 뉴스 모니터링 배치에서 실제 DB 저장이 활성화되었습니다.

* **보안**
  * `/api/admin/**` 엔드포인트가 인증 없이 접근 가능하도록 변경되고, 기존 테스트용 공개 엔드포인트는 폐지되었습니다.

* **코드 스타일 및 문서**
  * 일부 주석 및 JavaDoc이 정리되었습니다.
  * 불필요한 주석 및 임시 코드가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->