### PR TITLE
✨ [기능 추가] : 카카오 메시지 클릭 시, 해당 뉴스 기사로 리다이렉션 되는 기능 추가

### DIFF
--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Kakao/controller/RedirectController.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Kakao/controller/RedirectController.java
@@ -1,0 +1,36 @@
+package Baemin.News_Deliver.Domain.Kakao.controller;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Controller
+public class RedirectController {
+
+    /**
+     * 메시지를 전송 받은 유저가, 뉴스 기사를 클릭하면 리다이렉트를 진행해주는 컨트롤러
+     *
+     * @param target 타깃 url (유저가 누른 뉴스기사의 url)
+     * @param response 응답
+     * @throws IOException IO 예외
+     */
+    @GetMapping("/redirect")
+    public void redirectToTarget(@RequestParam("target") String target, HttpServletResponse response) throws IOException {
+
+        // URL 디코딩 (이미 인코딩된 URL이 들어오므로 디코딩 후 사용)
+        String decodedUrl = URLDecoder.decode(target, StandardCharsets.UTF_8);
+
+        // 유저가 입장한 페이지 로깅
+        log.info("Redirecting to external URL: {}", decodedUrl);
+
+        // 리다이렉트 수행
+        response.sendRedirect(decodedUrl);
+    }
+}

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Kakao/service/KakaoMessageService.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/Domain/Kakao/service/KakaoMessageService.java
@@ -145,7 +145,8 @@ public class KakaoMessageService {
             String templateArgsJson = objectMapper.writeValueAsString(templateArgs);
 
             MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-            params.add("template_id", "122080");
+            // params.add("template_id", "122080");
+            params.add("template_id", "122693");
             params.add("template_args", templateArgsJson);
 
             /* 세팅 별 개별 메시지 전송 */
@@ -222,8 +223,11 @@ public class KakaoMessageService {
         //메세지 5개 고정
         for (int i = 0; i < Math.min(5, newsList.size()); i++) {
             NewsEsDocument news = newsList.get(i);
+            templateArgs.put("TITLE" + (i + 1), news.getTitle());
             templateArgs.put("SUMMARY" + (i + 1), news.getSummary());
             templateArgs.put("PUBLISHER" + (i + 1), news.getPublisher());
+            templateArgs.put("CONTENTURL" + (i + 1), "redirect?target=" + news.getContent_url());
+            // templateArgs.put("CONTENTURL" + (i + 1), news.getContent_url());
         }
         return templateArgs;
 

--- a/SpringBoot/src/main/java/Baemin/News_Deliver/SecurityConfig.java
+++ b/SpringBoot/src/main/java/Baemin/News_Deliver/SecurityConfig.java
@@ -48,6 +48,7 @@ public class SecurityConfig {
                         //  공개 접근 허용 (인증 불필요)
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/").permitAll()
+                        .requestMatchers("/redirect").permitAll() // 유저가 카카오톡 메시지 클릭 시, 호출하는 API (항상 열어놔야 함)
                         .requestMatchers("/api/auth/status").permitAll()
                         .requestMatchers("/login/oauth2/**").permitAll()
                         .requestMatchers("/oauth2/**").permitAll()


### PR DESCRIPTION
### 구현 기능
카카오 메시지의 아이템 클릭 시 해당 url로 리다리엑션 되는 API

### 구현 방법 
서비스의 주소를 중간 경유하여, 서비스 내부의 controller에서 뉴스 기사 url로 전송

### Security 추가 
security에 위 기능에 대한 접근은 permitall로 추가

### 카카오톡 templte 변화 
카카오톡 템플릿을 추가 커스터마이징 하여, 적용함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 사용자를 지정된 URL로 리다이렉트하는 `/redirect` 엔드포인트가 추가되었습니다.

* **기능 개선**
  * 카카오 메시지 전송 시 템플릿 ID가 변경되었으며, 뉴스 제목 및 리다이렉트 링크가 메시지에 포함됩니다.

* **보안**
  * `/redirect` 엔드포인트에 대한 비인증 접근이 허용되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->